### PR TITLE
update parse-bmfont-xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mime": "^1.3.4",
     "parse-bmfont-ascii": "^1.0.3",
     "parse-bmfont-binary": "^1.0.5",
-    "parse-bmfont-xml": "^1.1.0",
+    "parse-bmfont-xml": "^1.1.4",
     "xhr": "^2.0.1",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
fixes exception when .fnt xml doesn't doesn't have kernings

https://github.com/mattdesl/parse-bmfont-xml/pull/2

related to: https://github.com/oliver-moran/jimp/issues/205