### PR TITLE
buidl: update mime dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ function parseFont(file, data, cb) {
 
   try {
     if (binary) result = readBinary(data)
-    else if (/json/.test(mime.lookup(file)) || data.charAt(0) === '{')
+    else if (/json/.test(mime.getType(file)) || data.charAt(0) === '{')
       result = JSON.parse(data)
-    else if (/xml/.test(mime.lookup(file)) || data.charAt(0) === '<')
+    else if (/xml/.test(mime.getType(file)) || data.charAt(0) === '<')
       result = parseXML(data)
     else result = parseASCII(data)
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "buffer-equal": "0.0.1",
-    "mime": "^1.3.4",
+    "mime": "^3.0.0",
     "parse-bmfont-ascii": "^1.0.3",
     "parse-bmfont-binary": "^1.0.5",
     "parse-bmfont-xml": "^1.1.4",


### PR DESCRIPTION
Hello, this PR updates the `mime` dependency to use the latest version and make it easy to dedupe when you are installing this library with other npm libraries 🙂