### PR TITLE
fixes deprecated & vulnerable phin dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "parse-bmfont-ascii": "^1.0.3",
     "parse-bmfont-binary": "^1.0.5",
     "parse-bmfont-xml": "^1.1.4",
-    "phin": "^2.9.1",
+    "phin": "^3.7.1",
     "xhr": "^2.0.1",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [x ] Other, please describe:

" Updated the phin dependency to a non-deprecated, non-vulnerable version and updated the usage. 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x ] No

**Did you test your solution?**

- [ x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

The original test.js passed all tests. 

## Problem Description

[The dependency phin@2.9.1 is deprecated and is marked as a vulnerability.](https://security.snyk.io/package/npm/phin)

## Solution Description

Updated phin to a non-deprecated version, 3.7.1.
The phin function no longer accepts a callback function, it returns an object of type `Promise<http.serverResponse>`, updated the call to await this function call and only pass in opt. The result is passed into a refactored version of handleData. 

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [ ] N/A

**Additional comments:**
Fixes #11 